### PR TITLE
Upgrading .net to 8.0 for Linux Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ src/.vs/
 *.suo
 *.user
 *.DotSettings
+*.vs/
+build/Fody*.xml
+build/Fody*.xsd

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
 
     <!-- Make sure start same folder .NET Core CLI and Visual Studio -->
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="1.0.0-rc0002" />
-    <PackageReference Include="Cake.MarkdownToPdf" Version="2.5.2" />
+    <PackageReference Include="Cake.Frosting" Version="4.0.0" />
+    <PackageReference Include="Cake.MarkdownToPdf" Version="3.0.5" />
     <PackageReference Include="Costura.Fody" Version="5.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Eve-O-Preview/Eve-O-Preview.csproj
+++ b/src/Eve-O-Preview/Eve-O-Preview.csproj
@@ -9,8 +9,8 @@
     <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EveOPreview</RootNamespace>
-    <AssemblyName>EVE-O Preview</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <AssemblyName>EVE-O-Preview</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
@@ -232,6 +232,10 @@
     </PackageReference>
     <PackageReference Include="Fody">
       <Version>4.0.2</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Fody" Version="6.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Eve-O-Preview/Presenters/Implementation/MainFormPresenter.cs
+++ b/src/Eve-O-Preview/Presenters/Implementation/MainFormPresenter.cs
@@ -233,7 +233,7 @@ namespace EveOPreview.Presenters
 		private string GetApplicationVersion()
 		{
 			Version version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version;
-			return $"{version.Major}.{version.Minor}.{version.Build}";
+			return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
 		}
 
 		private void ExitApplication()

--- a/src/Eve-O-Preview/Properties/AssemblyInfo.cs
+++ b/src/Eve-O-Preview/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("EVE-O Preview")]
+[assembly: AssemblyTitle("EVE-O-Preview")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("04f08f8d-9e98-423b-acdb-4effb31c0d35")]
-[assembly: AssemblyVersion("6.0.1.3")]
-[assembly: AssemblyFileVersion("6.0.1.3")]
+[assembly: AssemblyVersion("8.0.0.0")]
+[assembly: AssemblyFileVersion("8.0.0.0")]
 
 [assembly: CLSCompliant(false)]

--- a/src/Eve-O-Preview/Properties/Resources.Designer.cs
+++ b/src/Eve-O-Preview/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace EveOPreview.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/Eve-O-Preview/app.config
+++ b/src/Eve-O-Preview/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/src/Eve-O-Preview/app.manifest
+++ b/src/Eve-O-Preview/app.manifest
@@ -39,7 +39,7 @@
       <!-- Windows 8.1 -->
       <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
 
-      <!-- Windows 10 -->
+      <!-- Windows 10 and Windows 11 -->
       <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
 
     </application>


### PR DESCRIPTION
    - Added ignored folders to gitignore
    - Updated Eve-O Preview.exe name to Eve-O-Preview.exe
    - Updated .net from 4.6.2 framework to 4.8 famework along with .net 8
    - Fixed the version to display the Revision.
        - Previous was Major.Minor.Build to Major.Minor.Build.Revision