### PR TITLE
add .editorconfig to specify code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+# Indentation and spacing
+indent_size = tab
+indent_style = tab
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false


### PR DESCRIPTION
This PR adds an EditorConfig file to specify basic code style.

[EditorConfig](https://editorconfig.org/) is a standard way of configuring certain coding style related settings, supported by many editors such as Visual Studio, VSCode, Neovim. Visual Studio has the support built-in, while some editors (VSCode) require a plugin.

**Reasoning**

Originally the project is using tabs for indentation, but there is already PRs coming in that use spaces instead. Since VS uses a tab width of 4 by default, it can be difficult for contributors to realize that they are mixing indentation styles.

Example of how the mixup might look like (screenshot from another open PR):
![image](https://github.com/user-attachments/assets/e18140cb-31a9-4faf-8efd-aa95201527a7)

I propose that we keep to the original coding style used in this project instead of mixing in different styles. Adding the `.editorconfig` means individual developers don't need to tweak their editor settings to follow the code style.

**Details of the settings**

The `.editorconfig` included here will add the following settings for all `.cs` files:

Use the tab character for indentation instead of spaces. Not my personal preference, but this is what the project originally uses.
```
indent_size = tab
indent_style = tab
```

The Tab character will be represented by 4 spaces. This is again not my personal preference, but it is the default used by VS, and probably the value that was used while developing EVE-O Preview.
```
tab_width = 4
```

Use windows line endings. This might become important if Linux users contribute project, since their editor might use unix line endings instead.

```
end_of_line = crlf
```

This setting is not that important, but specifying it here might reduce the amount of one-line changes in commits.
```
insert_final_newline = false
```

**Possible additional settings**

The [EditorConfig syntax](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties) is quite simple, and is mainly used for specifying indentation, line endings and charset.

Visual Studio does have some more detailed options that can be specified as well. For example, these could be used to configure whether or not curly brackets after an `if` statement should be on a new line or not.

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options

I did not add any of these more detailed settings here, since I think the original project is pretty much using the default settings in Visual Studio.
