### PR TITLE
preview windows resize on startup incorrectly

### DIFF
--- a/src/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/src/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -56,6 +56,7 @@ namespace EveOPreview.Configuration.Implementation
 
 			this.MinimizeToTray = false;
 			this.ThumbnailRefreshPeriod = 500;
+			this.ThumbnailResizeTimeoutPeriod = 500;
 
 			this.EnableCompatibilityMode = false;
 
@@ -130,7 +131,8 @@ namespace EveOPreview.Configuration.Implementation
 
 		public bool MinimizeToTray { get; set; }
 		public int ThumbnailRefreshPeriod { get; set; }
-
+		public int ThumbnailResizeTimeoutPeriod { get; set; }
+		
 		[JsonProperty("CompatibilityMode")]
 		public bool EnableCompatibilityMode { get; set; }
 
@@ -328,6 +330,7 @@ namespace EveOPreview.Configuration.Implementation
 		public void ApplyRestrictions()
 		{
 			this.ThumbnailRefreshPeriod = ThumbnailConfiguration.ApplyRestrictions(this.ThumbnailRefreshPeriod, 300, 1000);
+			this.ThumbnailResizeTimeoutPeriod = ThumbnailConfiguration.ApplyRestrictions(this.ThumbnailResizeTimeoutPeriod, 200, 5000);
 			this.ThumbnailSize = new Size(ThumbnailConfiguration.ApplyRestrictions(this.ThumbnailSize.Width, this.ThumbnailMinimumSize.Width, this.ThumbnailMaximumSize.Width),
 				ThumbnailConfiguration.ApplyRestrictions(this.ThumbnailSize.Height, this.ThumbnailMinimumSize.Height, this.ThumbnailMaximumSize.Height));
 			this.ThumbnailOpacity = ThumbnailConfiguration.ApplyRestrictions((int)(this.ThumbnailOpacity * 100.00), 20, 100) / 100.00;

--- a/src/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/src/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -19,7 +19,7 @@ namespace EveOPreview.Configuration
 
 		bool MinimizeToTray { get; set; }
 		int ThumbnailRefreshPeriod { get; set; }
-
+		int ThumbnailResizeTimeoutPeriod { get; set; }
 		bool EnableCompatibilityMode { get; set; }
 
 		double ThumbnailOpacity { get; set; }

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -12,7 +12,7 @@ namespace EveOPreview.View
 	public abstract partial class ThumbnailView : Form, IThumbnailView
 	{
 		#region Private constants
-		private const int RESIZE_EVENT_TIMEOUT = 500;
+		// private const int RESIZE_EVENT_TIMEOUT = 500;
 		private const double OPACITY_THRESHOLD = 0.9;
 		private const double OPACITY_EPSILON = 0.1;
 		#endregion
@@ -50,6 +50,7 @@ namespace EveOPreview.View
 
 		protected ThumbnailView(IWindowManager windowManager, IThumbnailConfiguration config, IThumbnailManager thumbnailManager)
 		{
+			this._config = config;
 			this.SuppressResizeEvent();
 
 			this.WindowManager = windowManager;
@@ -73,7 +74,6 @@ namespace EveOPreview.View
 
 			this._overlay = new ThumbnailOverlay(this, this.MouseDown_Handler);
 
-			this._config = config;
 			SetDefaultBorderColor();
 			this._thumbnailManager = thumbnailManager;
 		}
@@ -453,7 +453,7 @@ namespace EveOPreview.View
 		{
 			// Workaround for WinForms issue with the Resize event being fired with inconsistent ClientSize value
 			// Any Resize events fired before this timestamp will be ignored
-			this._suppressResizeEventsTimestamp = DateTime.UtcNow.AddMilliseconds(ThumbnailView.RESIZE_EVENT_TIMEOUT);
+			this._suppressResizeEventsTimestamp = DateTime.UtcNow.AddMilliseconds(_config.ThumbnailResizeTimeoutPeriod);
 		}
 
 		#region GUI events

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -12,7 +12,6 @@ namespace EveOPreview.View
 	public abstract partial class ThumbnailView : Form, IThumbnailView
 	{
 		#region Private constants
-		// private const int RESIZE_EVENT_TIMEOUT = 500;
 		private const double OPACITY_THRESHOLD = 0.9;
 		private const double OPACITY_EPSILON = 0.1;
 		#endregion

--- a/src/Eve-O-Preview/app.config
+++ b/src/Eve-O-Preview/app.config
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+	</startup>
+	<System.Windows.Forms.ApplicationConfigurationSection>
+		<add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+	</System.Windows.Forms.ApplicationConfigurationSection>
+</configuration>


### PR DESCRIPTION
added configuration item ThumbnailResizeTimeoutPeriod to replace hardcoded 500ms timeout allowing users to set higher values to prevent incorrect window resize on startup.