### PR TITLE
main form - resize on startup based on tabsize and tab number

### DIFF
--- a/src/Eve-O-Preview/Properties/AssemblyInfo.cs
+++ b/src/Eve-O-Preview/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("04f08f8d-9e98-423b-acdb-4effb31c0d35")]
-[assembly: AssemblyVersion("8.0.1.2")]
-[assembly: AssemblyFileVersion("8.0.1.2")]
+[assembly: AssemblyVersion("8.0.1.3")]
+[assembly: AssemblyFileVersion("8.0.1.3")]
 
 [assembly: CLSCompliant(false)]

--- a/src/Eve-O-Preview/View/Implementation/MainForm.cs
+++ b/src/Eve-O-Preview/View/Implementation/MainForm.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace EveOPreview.View
@@ -34,6 +35,7 @@ namespace EveOPreview.View
 
 			this.InitZoomAnchorMap();
 			this.InitOverlayLabelMap();
+			this.InitFormSize();
 		}
 
 		public bool MinimizeToTray
@@ -498,5 +500,20 @@ namespace EveOPreview.View
             this._overlayLabelMap[ViewZoomAnchor.S] = this.OverlayLabelSRadioButton;
             this._overlayLabelMap[ViewZoomAnchor.SE] = this.OverlayLabelSERadioButton;
         }
+		private void InitFormSize()
+		{
+			const int BUFFER_PIXEL_AMOUNT = 8;
+			// resize form height based on tabbed control item height
+			var tabControl = (System.Windows.Forms.TabControl)this.Controls.Find("ContentTabControl", false).First();
+			if (tabControl != null)
+			{
+				var furnitureSize = this.Height - tabControl.Height;
+				var calculatedHeight = (tabControl.ItemSize.Width * tabControl.Controls.Count) + furnitureSize + BUFFER_PIXEL_AMOUNT;
+				if (this.Height < calculatedHeight)
+				{
+					this.Height = calculatedHeight;
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Some chinese clients having issues with mainform size as tabs seem slightly bigger. Have altered startup code to ensure mainform is calculated using number of tabs and tab size