### PR TITLE
preview windows fixes #46 and #47 initial preview size and click on overlay label

### DIFF
--- a/src/Eve-O-Preview/Properties/AssemblyInfo.cs
+++ b/src/Eve-O-Preview/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("04f08f8d-9e98-423b-acdb-4effb31c0d35")]
-[assembly: AssemblyVersion("8.0.1.5")]
-[assembly: AssemblyFileVersion("8.0.1.5")]
+[assembly: AssemblyVersion("8.0.1.6")]
+[assembly: AssemblyFileVersion("8.0.1.6")]
 
 [assembly: CLSCompliant(false)]

--- a/src/Eve-O-Preview/View/Implementation/MainForm.cs
+++ b/src/Eve-O-Preview/View/Implementation/MainForm.cs
@@ -28,8 +28,8 @@ namespace EveOPreview.View
 			this._overlayLabelMap = new Dictionary<ViewZoomAnchor, RadioButton>();
 			this._cachedThumbnailZoomAnchor = ViewZoomAnchor.NW;
 			this._suppressEvents = false;
-			this._minimumSize = new Size(80, 60);
-			this._maximumSize = new Size(80, 60);
+			this._minimumSize = new Size(20, 20);
+			this._maximumSize = new Size(20, 20);
 
 			InitializeComponent();
 

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailOverlay.Designer.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailOverlay.Designer.cs
@@ -57,6 +57,7 @@
 			this.OverlayLabel.Size = new System.Drawing.Size(25, 13);
 			this.OverlayLabel.TabIndex = 1;
 			this.OverlayLabel.Text = "...";
+			this.OverlayLabel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.OverlayArea_Click);
 			// 
 			// ThumbnailOverlay
 			// 

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.Designer.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.Designer.cs
@@ -28,7 +28,7 @@ namespace EveOPreview.View
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(64, 64);
+			this.MinimumSize = new System.Drawing.Size(20, 20);
 			this.Name = "ThumbnailView";
 			this.Opacity = 0.1D;
 			this.ShowIcon = false;


### PR DESCRIPTION
#46 fix bug with minimum preview size on startup
#47 treat click on overlay text same as click on main preview