### PR TITLE
fix: fix flatpak wmctrl interaction

### DIFF
--- a/src/Eve-O-Preview/Services/Implementation/WindowManager.cs
+++ b/src/Eve-O-Preview/Services/Implementation/WindowManager.cs
@@ -139,7 +139,7 @@ namespace EveOPreview.Services.Implementation
                 // If we are in a flatpak, then use flatpak-spawn to run wmctrl outside the sandbox
                 if (Environment.GetEnvironmentVariable("container") == "flatpak")
                 {
-                    cmd = $"-c \"flatpak-spawn --host {this._wmctrlLocation}/wmctrl -a \"\"" + windowName + "\"\"\"";
+                    cmd = $"-c \"flatpak-spawn --host wmctrl -a \"\"" + windowName + "\"\"\"";
                 } 
                 else 
                 {


### PR DESCRIPTION
 by removing absolute path in flatpak-spawn command. This will rely on the host path and work in more circumstances since most flatpaks don't allow access to /usr/bin. Even if the flatpak can locate the wmctrl binary, it may not be at the same location as it is on the host which will fail when using flatpak-spawn --host. Therefore, relying on the host's PATH makes sense in most cases IMO.
 
fixes #72 