### PR TITLE
Fix GDI handle leak

### DIFF
--- a/src/Eve-O-Preview/Services/Implementation/WindowManager.cs
+++ b/src/Eve-O-Preview/Services/Implementation/WindowManager.cs
@@ -304,7 +304,9 @@ namespace EveOPreview.Services.Implementation
 			// Check if there is anything to make thumbnail of
 			if ((width < WINDOW_SIZE_THRESHOLD) || (height < WINDOW_SIZE_THRESHOLD))
 			{
-				return null;
+                User32NativeMethods.ReleaseDC(source, sourceContext);
+
+                return null;
 			}
 
 			var destContext = Gdi32NativeMethods.CreateCompatibleDC(sourceContext);


### PR DESCRIPTION
If either `width` or `height` is less than the `WINDOWS_SIZE_THRESHOLD`, the previosly acquired GDI handle `sourceContext` won't get released