### PR TITLE
Add mouse button (M3/M4/M5) support for client cycling and minimize-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,38 @@ Should you wish to remove these HotKeys completely, Simply set the values to emp
 	  "CycleGroup5BackwardHotkeys": [],
 	  "CycleGroup5ClientsOrder": {}
 
+### Cycle Clients with Mouse Buttons
+
+In addition to keyboard hotkeys, the cycle groups can be triggered directly by the **middle mouse button (M3)** and the two side buttons **M4** and **M5** — no need to remap them to keyboard keys in your mouse software first.
+
+Mouse buttons live in the *same* `CycleGroupNForwardHotkeys` / `CycleGroupNBackwardHotkeys` lists as keyboard hotkeys; just add the mouse token alongside (or instead of) your keys. For example, to cycle group 1 forward with M5 and backward with M4, while keeping the F-key bindings:
+
+    "CycleGroup1ForwardHotkeys": [
+      "F14",
+      "Control+F14",
+      "M5",
+      "Control+M5"
+    ],
+    "CycleGroup1BackwardHotkeys": [
+      "F13",
+      "M4"
+    ]
+
+The accepted button tokens are:
+
+| Button | Tokens (any are accepted, case-insensitive) |
+| --- | --- |
+| Middle mouse button | **M3**, **Middle**, **MButton** |
+| Side button 1 | **M4**, **Mouse4**, **XButton1** |
+| Side button 2 | **M5**, **Mouse5**, **XButton2** |
+
+Modifiers work exactly like keyboard hotkeys: prefix with **Control+**, **Shift+**, and/or **Alt+** (e.g. **Control+M5**). As with keyboard hotkeys, the match is exact — a plain **M5** fires only when no modifier is held, so if you want it to also fire while holding Control (e.g. mid Ctrl-click in EVE) add **Control+M5** as a second entry.
+
+**Notes:**
+* Only buttons you actually bind are intercepted. An unbound middle-click (or a plain M3 when you've only bound **Control+M3**) still passes through to whatever is under the cursor as normal.
+* A bound button is consumed by EVE-O Preview and is **not** passed on to EVE (the same behaviour as cycle hotkeys).
+* The standard left and right mouse buttons cannot be bound here — they are reserved for clicking/dragging the thumbnails themselves.
+
 ### Minimize All Clients with Hotkey Setup
 
 In a similar pattern to the per client Hotkey Setup, It is possible to set a key combinations to Minimize all the Eve Windows. EVE-O Preview doesn't provide any GUI to set the these hotkeys. It should be done via editing the configuration file directly. Don't forget to make a backup copy of the file before editing it.
@@ -254,6 +286,8 @@ In a similar pattern to the per client Hotkey Setup, It is possible to set a key
   "MinimizeAllClientsHotkeys": [
     "F22"
   ],
+
+The same mouse buttons (**M3** / **M4** / **M5**, with optional **Control+** / **Shift+** / **Alt+** modifiers) can be used here too, e.g. `"Control+M3"`.
 
 
 **Hints** 

--- a/src/Eve-O-Preview/Hotkeys/MouseHookHandler.cs
+++ b/src/Eve-O-Preview/Hotkeys/MouseHookHandler.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace EveOPreview.UI.Hotkeys
+{
+	public enum MouseButton
+	{
+		Middle,
+		XButton1, // "M4"
+		XButton2  // "M5"
+	}
+
+	/// <summary>
+	/// Owns a single system-wide low-level mouse hook (WH_MOUSE_LL) and dispatches
+	/// configured (button + modifier) combinations to registered callbacks.
+	/// This is the mouse-side analogue of <see cref="HotkeyHandler"/>: keyboard hotkeys
+	/// use RegisterHotKey (keyboard only), whereas mouse buttons can only be captured
+	/// globally through a low-level hook.
+	/// </summary>
+	sealed class MouseHookHandler : IDisposable
+	{
+		private sealed class Binding
+		{
+			public MouseButton Button;
+			public Keys Modifiers; // exact set of Control/Shift/Alt required
+			public Action Callback;
+		}
+
+		#region Private fields
+		// The delegate MUST be kept referenced for the lifetime of the hook,
+		// otherwise the GC collects it and the native callback crashes the process.
+		private readonly MouseHookNativeMethods.LowLevelMouseProc _hookProc;
+		private readonly List<Binding> _bindings;
+
+		private IntPtr _hookId;
+
+		// When a bound button-down is swallowed we latch the button so its paired
+		// button-up can be swallowed too, leaving no dangling button state in the
+		// target application.
+		private MouseButton? _swallowedButton;
+		#endregion
+
+		public MouseHookHandler()
+		{
+			this._hookProc = this.HookCallback;
+			this._bindings = new List<Binding>();
+			this._hookId = IntPtr.Zero;
+			this._swallowedButton = null;
+		}
+
+		public bool HasBindings => this._bindings.Count > 0;
+
+		public void AddBinding(MouseButton button, Keys modifiers, Action callback)
+		{
+			this._bindings.Add(new Binding { Button = button, Modifiers = modifiers, Callback = callback });
+		}
+
+		/// <summary>Installs the hook if there is at least one binding. Idempotent.</summary>
+		public void Hook()
+		{
+			if ((this._hookId != IntPtr.Zero) || (this._bindings.Count == 0))
+			{
+				return;
+			}
+
+			// WH_MOUSE_LL is a global hook; passing the executable's module handle is
+			// sufficient. The callback is delivered to this (the installing) thread's
+			// message queue - which is the WinForms UI thread, so callbacks may touch
+			// UI safely without marshaling.
+			IntPtr module = MouseHookNativeMethods.GetModuleHandle(null);
+			this._hookId = MouseHookNativeMethods.SetWindowsHookEx(MouseHookNativeMethods.WH_MOUSE_LL, this._hookProc, module, 0);
+		}
+
+		public void Unhook()
+		{
+			if (this._hookId == IntPtr.Zero)
+			{
+				return;
+			}
+
+			MouseHookNativeMethods.UnhookWindowsHookEx(this._hookId);
+			this._hookId = IntPtr.Zero;
+		}
+
+		public void Dispose()
+		{
+			this.Unhook();
+			GC.SuppressFinalize(this);
+		}
+
+		~MouseHookHandler()
+		{
+			this.Unhook();
+		}
+
+		private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+		{
+			if (nCode != MouseHookNativeMethods.HC_ACTION)
+			{
+				return MouseHookNativeMethods.CallNextHookEx(this._hookId, nCode, wParam, lParam);
+			}
+
+			int message = wParam.ToInt32();
+
+			// Swallow the button-up that pairs with a button-down we already consumed
+			if ((message == MouseHookNativeMethods.WM_MBUTTONUP) || (message == MouseHookNativeMethods.WM_XBUTTONUP))
+			{
+				if (this._swallowedButton.HasValue && this.TryGetButton(message, lParam, out MouseButton releasedButton) && (releasedButton == this._swallowedButton.Value))
+				{
+					this._swallowedButton = null;
+					return (IntPtr)1;
+				}
+
+				return MouseHookNativeMethods.CallNextHookEx(this._hookId, nCode, wParam, lParam);
+			}
+
+			if ((message != MouseHookNativeMethods.WM_MBUTTONDOWN) && (message != MouseHookNativeMethods.WM_XBUTTONDOWN))
+			{
+				return MouseHookNativeMethods.CallNextHookEx(this._hookId, nCode, wParam, lParam);
+			}
+
+			if (!this.TryGetButton(message, lParam, out MouseButton button))
+			{
+				return MouseHookNativeMethods.CallNextHookEx(this._hookId, nCode, wParam, lParam);
+			}
+
+			Keys modifiers = MouseHookHandler.GetCurrentModifiers();
+
+			Action callback = null;
+			foreach (Binding binding in this._bindings)
+			{
+				if ((binding.Button == button) && (binding.Modifiers == modifiers))
+				{
+					callback = binding.Callback;
+					break;
+				}
+			}
+
+			if (callback == null)
+			{
+				// Not bound - let the click pass through to whatever is underneath
+				return MouseHookNativeMethods.CallNextHookEx(this._hookId, nCode, wParam, lParam);
+			}
+
+			this._swallowedButton = button;
+
+			try
+			{
+				callback();
+			}
+			catch
+			{
+				// A failure in the cycle logic must never break the global mouse hook
+			}
+
+			// Consume the event so it does not reach the focused application (e.g. EVE)
+			return (IntPtr)1;
+		}
+
+		private bool TryGetButton(int message, IntPtr lParam, out MouseButton button)
+		{
+			if ((message == MouseHookNativeMethods.WM_MBUTTONDOWN) || (message == MouseHookNativeMethods.WM_MBUTTONUP))
+			{
+				button = MouseButton.Middle;
+				return true;
+			}
+
+			// X button: which one is encoded in the high word of mouseData
+			MouseHookNativeMethods.MSLLHOOKSTRUCT data = System.Runtime.InteropServices.Marshal.PtrToStructure<MouseHookNativeMethods.MSLLHOOKSTRUCT>(lParam);
+			int xButton = (int)((data.mouseData >> 16) & 0xFFFF);
+
+			switch (xButton)
+			{
+				case MouseHookNativeMethods.XBUTTON1:
+					button = MouseButton.XButton1;
+					return true;
+				case MouseHookNativeMethods.XBUTTON2:
+					button = MouseButton.XButton2;
+					return true;
+				default:
+					button = MouseButton.Middle;
+					return false;
+			}
+		}
+
+		private static Keys GetCurrentModifiers()
+		{
+			Keys modifiers = Keys.None;
+
+			if (MouseHookHandler.IsKeyDown(MouseHookNativeMethods.VK_CONTROL))
+			{
+				modifiers |= Keys.Control;
+			}
+
+			if (MouseHookHandler.IsKeyDown(MouseHookNativeMethods.VK_SHIFT))
+			{
+				modifiers |= Keys.Shift;
+			}
+
+			if (MouseHookHandler.IsKeyDown(MouseHookNativeMethods.VK_MENU))
+			{
+				modifiers |= Keys.Alt;
+			}
+
+			return modifiers;
+		}
+
+		private static bool IsKeyDown(int virtualKey)
+		{
+			return (MouseHookNativeMethods.GetKeyState(virtualKey) & 0x8000) != 0;
+		}
+
+		/// <summary>
+		/// Attempts to interpret a configuration token (e.g. "M4", "Control+M5",
+		/// "XButton1", "Middle") as a mouse-button binding. Returns false for any
+		/// token whose key portion is not a recognised mouse button, in which case
+		/// the token should be treated as a keyboard hotkey instead.
+		/// </summary>
+		public static bool TryParse(string token, out MouseButton button, out Keys modifiers)
+		{
+			button = MouseButton.Middle;
+			modifiers = Keys.None;
+
+			if (string.IsNullOrWhiteSpace(token))
+			{
+				return false;
+			}
+
+			string[] parts = token.Split('+');
+			string keyPart = parts[parts.Length - 1].Trim();
+
+			if (!MouseHookHandler.TryParseButton(keyPart, out button))
+			{
+				return false;
+			}
+
+			for (int i = 0; i < parts.Length - 1; i++)
+			{
+				switch (parts[i].Trim().ToLowerInvariant())
+				{
+					case "control":
+					case "ctrl":
+						modifiers |= Keys.Control;
+						break;
+					case "shift":
+						modifiers |= Keys.Shift;
+						break;
+					case "alt":
+						modifiers |= Keys.Alt;
+						break;
+					default:
+						// Unknown modifier - reject so it is not silently misbound
+						return false;
+				}
+			}
+
+			return true;
+		}
+
+		private static bool TryParseButton(string value, out MouseButton button)
+		{
+			switch (value.ToLowerInvariant())
+			{
+				case "mbutton":
+				case "middle":
+				case "m3":
+					button = MouseButton.Middle;
+					return true;
+				case "xbutton1":
+				case "mouse4":
+				case "m4":
+					button = MouseButton.XButton1;
+					return true;
+				case "xbutton2":
+				case "mouse5":
+				case "m5":
+					button = MouseButton.XButton2;
+					return true;
+				default:
+					button = MouseButton.Middle;
+					return false;
+			}
+		}
+	}
+}

--- a/src/Eve-O-Preview/Hotkeys/MouseHookHandler.cs
+++ b/src/Eve-O-Preview/Hotkeys/MouseHookHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace EveOPreview.UI.Hotkeys
@@ -39,6 +40,10 @@ namespace EveOPreview.UI.Hotkeys
 		// button-up can be swallowed too, leaving no dangling button state in the
 		// target application.
 		private MouseButton? _swallowedButton;
+
+		// The bound cycle action is posted here (the UI thread's message loop) rather than being
+		// invoked inside the hook callback, which sits on the system input path.
+		private readonly SynchronizationContext _syncContext;
 		#endregion
 
 		public MouseHookHandler()
@@ -47,6 +52,10 @@ namespace EveOPreview.UI.Hotkeys
 			this._bindings = new List<Binding>();
 			this._hookId = IntPtr.Zero;
 			this._swallowedButton = null;
+
+			// Captured on the UI thread (the hook is created during startup on that thread) so the
+			// hook callback can post work to the message loop instead of executing it inline.
+			this._syncContext = SynchronizationContext.Current;
 		}
 
 		public bool HasBindings => this._bindings.Count > 0;
@@ -145,13 +154,35 @@ namespace EveOPreview.UI.Hotkeys
 
 			this._swallowedButton = button;
 
-			try
+			// Run the cycle action on the UI message loop, NOT inside this hook. This callback
+			// executes on the system input path; performing the foreground switch (AttachThreadInput
+			// + SetForegroundWindow) inline can wedge the target window's input queue. Posting it makes
+			// the mouse path behave like the keyboard-hotkey path, which already runs in the normal pump.
+			Action toRun = callback;
+			if (this._syncContext != null)
 			{
-				callback();
+				this._syncContext.Post(_ =>
+				{
+					try
+					{
+						toRun();
+					}
+					catch
+					{
+						// Never let a cycle error crash the app
+					}
+				}, null);
 			}
-			catch
+			else
 			{
-				// A failure in the cycle logic must never break the global mouse hook
+				try
+				{
+					toRun();
+				}
+				catch
+				{
+					// Never let a cycle error break the global mouse hook
+				}
 			}
 
 			// Consume the event so it does not reach the focused application (e.g. EVE)

--- a/src/Eve-O-Preview/Hotkeys/MouseHookNativeMethods.cs
+++ b/src/Eve-O-Preview/Hotkeys/MouseHookNativeMethods.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace EveOPreview.UI.Hotkeys
+{
+	static class MouseHookNativeMethods
+	{
+		public delegate IntPtr LowLevelMouseProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		public static extern IntPtr SetWindowsHookEx(int idHook, LowLevelMouseProc lpfn, IntPtr hMod, uint dwThreadId);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+		[DllImport("user32.dll")]
+		public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		public static extern IntPtr GetModuleHandle(string lpModuleName);
+
+		[DllImport("user32.dll")]
+		public static extern short GetKeyState(int nVirtKey);
+
+		[StructLayout(LayoutKind.Sequential)]
+		public struct MSLLHOOKSTRUCT
+		{
+			public int ptX;
+			public int ptY;
+			public uint mouseData;
+			public uint flags;
+			public uint time;
+			public IntPtr dwExtraInfo;
+		}
+
+		public const int WH_MOUSE_LL = 14;
+		public const int HC_ACTION = 0;
+
+		public const int WM_MBUTTONDOWN = 0x0207;
+		public const int WM_MBUTTONUP = 0x0208;
+		public const int WM_XBUTTONDOWN = 0x020B;
+		public const int WM_XBUTTONUP = 0x020C;
+
+		// For X-button messages the activated button is reported in the high word of mouseData
+		public const int XBUTTON1 = 0x0001;
+		public const int XBUTTON2 = 0x0002;
+
+		// Virtual key codes for modifier state queries
+		public const int VK_SHIFT = 0x10;
+		public const int VK_CONTROL = 0x11;
+		public const int VK_MENU = 0x12; // Alt
+	}
+}

--- a/src/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/src/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -52,6 +52,7 @@ namespace EveOPreview.Services
 		private int _hideThumbnailsDelay;
 
 		private List<HotkeyHandler> _cycleClientHotkeyHandlers = new List<HotkeyHandler>();
+		private readonly MouseHookHandler _mouseHookHandler;
 		#endregion
 
 		public ThumbnailManager(IMediator mediator, IThumbnailConfiguration configuration, IProcessMonitor processMonitor, IWindowManager windowManager, IThumbnailViewFactory factory)
@@ -80,22 +81,29 @@ namespace EveOPreview.Services
 
 			this._hideThumbnailsDelay = this._configuration.HideThumbnailsDelay;
 
-			RegisterCycleClientHotkey(this._configuration.CycleGroup1ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup1ClientsOrder);
-			RegisterCycleClientHotkey(this._configuration.CycleGroup1BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup1ClientsOrder);
+			this._mouseHookHandler = new MouseHookHandler();
 
-			RegisterCycleClientHotkey(this._configuration.CycleGroup2ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup2ClientsOrder);
-			RegisterCycleClientHotkey(this._configuration.CycleGroup2BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup2ClientsOrder);
+			// Each cycle binding may be a keyboard hotkey (RegisterHotKey) or a mouse
+			// button (low-level mouse hook). Both kinds share the same configuration lists.
+			RegisterCycleClientHotkey(this._configuration.CycleGroup1ForwardHotkeys, true, this._configuration.CycleGroup1ClientsOrder);
+			RegisterCycleClientHotkey(this._configuration.CycleGroup1BackwardHotkeys, false, this._configuration.CycleGroup1ClientsOrder);
 
-			RegisterCycleClientHotkey(this._configuration.CycleGroup3ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup3ClientsOrder);
-			RegisterCycleClientHotkey(this._configuration.CycleGroup3BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup3ClientsOrder);
+			RegisterCycleClientHotkey(this._configuration.CycleGroup2ForwardHotkeys, true, this._configuration.CycleGroup2ClientsOrder);
+			RegisterCycleClientHotkey(this._configuration.CycleGroup2BackwardHotkeys, false, this._configuration.CycleGroup2ClientsOrder);
 
-			RegisterCycleClientHotkey(this._configuration.CycleGroup4ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup4ClientsOrder);
-			RegisterCycleClientHotkey(this._configuration.CycleGroup4BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup4ClientsOrder);
+			RegisterCycleClientHotkey(this._configuration.CycleGroup3ForwardHotkeys, true, this._configuration.CycleGroup3ClientsOrder);
+			RegisterCycleClientHotkey(this._configuration.CycleGroup3BackwardHotkeys, false, this._configuration.CycleGroup3ClientsOrder);
 
-			RegisterCycleClientHotkey(this._configuration.CycleGroup5ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup5ClientsOrder);
-			RegisterCycleClientHotkey(this._configuration.CycleGroup5BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup5ClientsOrder);
+			RegisterCycleClientHotkey(this._configuration.CycleGroup4ForwardHotkeys, true, this._configuration.CycleGroup4ClientsOrder);
+			RegisterCycleClientHotkey(this._configuration.CycleGroup4BackwardHotkeys, false, this._configuration.CycleGroup4ClientsOrder);
 
-			RegisterMinimizeAllClientsHotkey(this._configuration.MinimizeAllClientsHotkeys?.Select(x => this._configuration.StringToKey(x)));
+			RegisterCycleClientHotkey(this._configuration.CycleGroup5ForwardHotkeys, true, this._configuration.CycleGroup5ClientsOrder);
+			RegisterCycleClientHotkey(this._configuration.CycleGroup5BackwardHotkeys, false, this._configuration.CycleGroup5ClientsOrder);
+
+			RegisterMinimizeAllClientsHotkey(this._configuration.MinimizeAllClientsHotkeys);
+
+			// Install the single shared mouse hook (no-op if no mouse buttons were bound)
+			this._mouseHookHandler.Hook();
 		}
 
 		public IThumbnailView GetClientByTitle(string title)
@@ -235,39 +243,43 @@ namespace EveOPreview.Services
 			return;
 		}
 
-		public void RegisterCycleClientHotkey(IEnumerable<Keys> keys, bool isForwards, Dictionary<string, int> cycleOrder)
+		public void RegisterCycleClientHotkey(IEnumerable<string> bindings, bool isForwards, Dictionary<string, int> cycleOrder)
 		{
-			foreach (var hotkey in keys)
-			{
-				if (hotkey == Keys.None)
-				{
-					return;
-				}
-
-				var newHandler = new HotkeyHandler(default(IntPtr), hotkey);
-				newHandler.Pressed += (object s, HandledEventArgs e) =>
-				{
-					this.CycleNextClient(isForwards, cycleOrder);
-					e.Handled = true;
-				};
-
-				newHandler.Register();
-				this._cycleClientHotkeyHandlers.Add(newHandler);
-			}
+			this.RegisterBindings(bindings, () => this.CycleNextClient(isForwards, cycleOrder));
 		}
-		public void RegisterMinimizeAllClientsHotkey(IEnumerable<Keys> keys)
+		public void RegisterMinimizeAllClientsHotkey(IEnumerable<string> bindings)
 		{
-			foreach (var hotkey in keys)
+			this.RegisterBindings(bindings, () => this.MinimizeAllClients());
+		}
+
+		// Registers each configuration token to the given action, routing mouse-button
+		// tokens (e.g. "M4", "Control+M5") to the low-level mouse hook and everything
+		// else to a keyboard hotkey via RegisterHotKey.
+		private void RegisterBindings(IEnumerable<string> bindings, Action action)
+		{
+			if (bindings == null)
 			{
+				return;
+			}
+
+			foreach (var token in bindings)
+			{
+				if (MouseHookHandler.TryParse(token, out MouseButton button, out Keys mouseModifiers))
+				{
+					this._mouseHookHandler.AddBinding(button, mouseModifiers, action);
+					continue;
+				}
+
+				Keys hotkey = this._configuration.StringToKey(token);
 				if (hotkey == Keys.None)
 				{
-					return;
+					continue;
 				}
 
 				var newHandler = new HotkeyHandler(default(IntPtr), hotkey);
 				newHandler.Pressed += (object s, HandledEventArgs e) =>
 				{
-					this.MinimizeAllClients();
+					action();
 					e.Handled = true;
 				};
 
@@ -286,6 +298,7 @@ namespace EveOPreview.Services
 		public void Stop()
 		{
 			this._thumbnailUpdateTimer.Stop();
+			this._mouseHookHandler.Unhook();
 		}
 
 		private void ThumbnailUpdateTimerTick(object sender, EventArgs e)

--- a/src/Eve-O-Preview/Services/Implementation/WindowManager.cs
+++ b/src/Eve-O-Preview/Services/Implementation/WindowManager.cs
@@ -199,9 +199,6 @@ namespace EveOPreview.Services.Implementation
 #if WINDOWS
 		public void ActivateWindow(IntPtr handle, AnimationStyle animation)
 		{
-			User32NativeMethods.SetForegroundWindow(handle);
-			User32NativeMethods.SetFocus(handle);
-
 			uint style = User32NativeMethods.GetWindowLong(handle, InteropConstants.GWL_STYLE);
 
 			if ((style & InteropConstants.WS_MINIMIZE) == InteropConstants.WS_MINIMIZE)
@@ -216,6 +213,46 @@ namespace EveOPreview.Services.Implementation
 						User32NativeMethods.ShowWindowAsync(handle, InteropConstants.SW_RESTORE);
 						RestoreAnimation();
 						break;
+				}
+			}
+
+			this.ForceSetForegroundWindow(handle);
+			User32NativeMethods.SetFocus(handle);
+		}
+
+		// Windows only allows a process to change the foreground window if it "received
+		// the last input event". A global mouse hook merely observes input destined for
+		// the EVE client, so a direct SetForegroundWindow call is refused (the target's
+		// taskbar button just flashes). Briefly attaching to the foreground window's
+		// input queue grants us that right. Paths that already hold it (thumbnail click,
+		// keyboard hotkey) are unaffected - the attach is harmless or a no-op there.
+		private void ForceSetForegroundWindow(IntPtr handle)
+		{
+			IntPtr foreground = User32NativeMethods.GetForegroundWindow();
+			if (foreground == handle)
+			{
+				return;
+			}
+
+			uint foreThread = User32NativeMethods.GetWindowThreadProcessId(foreground, out _);
+			uint appThread = User32NativeMethods.GetCurrentThreadId();
+
+			bool attached = false;
+			if ((foreThread != 0) && (foreThread != appThread))
+			{
+				attached = User32NativeMethods.AttachThreadInput(appThread, foreThread, true);
+			}
+
+			try
+			{
+				User32NativeMethods.BringWindowToTop(handle);
+				User32NativeMethods.SetForegroundWindow(handle);
+			}
+			finally
+			{
+				if (attached)
+				{
+					User32NativeMethods.AttachThreadInput(appThread, foreThread, false);
 				}
 			}
 		}

--- a/src/Eve-O-Preview/Services/Interop/User32NativeMethods.cs
+++ b/src/Eve-O-Preview/Services/Interop/User32NativeMethods.cs
@@ -14,6 +14,20 @@ namespace EveOPreview.Services.Interop
 		[DllImport("user32.dll")]
 		public static extern bool SetForegroundWindow(IntPtr window);
 
+		[DllImport("user32.dll", SetLastError = true)]
+		public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+
+		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool BringWindowToTop(IntPtr hWnd);
+
+		[DllImport("kernel32.dll")]
+		public static extern uint GetCurrentThreadId();
+
 		[DllImport("user32.dll")]
 		public static extern void SetFocus(IntPtr window);
 


### PR DESCRIPTION
## What
Adds the middle mouse button (M3) and side buttons M4/M5 - with optional
Control/Shift/Alt modifiers - as triggers for the cycle groups and
Minimize-All, alongside the existing keyboard hotkeys.

## How
- New `MouseHookHandler` / `MouseHookNativeMethods`: a single shared
  low-level mouse hook (`WH_MOUSE_LL`) with a small binding registry,
  exact-modifier matching, and bound-button swallowing (unbound buttons
  pass through).
- `ThumbnailManager` routes mouse tokens to the hook and keyboard tokens
  to `RegisterHotKey`, reusing the existing `CycleGroupNForward/Backward`
  and `MinimizeAllClients` config lists (tokens like `M5`, `Control+M4`).
- `WindowManager.ActivateWindow` uses `AttachThreadInput` so hook-triggered
  activation can change the foreground window (Windows otherwise refuses it
  from a background context).

## Config
Mouse tokens go in the existing hotkey lists, e.g.:
`"CycleGroup1ForwardHotkeys": [ "F14", "M5", "Control+M5" ]`
Accepts `M3/Middle/MButton`, `M4/Mouse4/XButton1`, `M5/Mouse5/XButton2`.

## Testing
Builds clean on both Windows and Linux targets. Verified live with real
EVE clients and in isolation (forward/back cycling switches the actual
foreground window; unbound buttons pass through). README docs added.
